### PR TITLE
Avoid overriding existing backface-visibility property

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 [PostCSS] plugin to insert 3D hack before [will-change] property.
 
-This plugin uses `backface-visibility` to force the browser to create a new layer.
-This is commonly done with `transform: translateZ(0)` and `transform: translate3d(0, 0, 0)`.
-`backface-visibility` is used here to avoid overriding the more popular transform property.
+This plugin uses `backface-visibility` to force the browser to create a new
+layer, without overriding existing `backface-visibility` properties. This CSS
+hack is commonly done with `transform: translateZ(0)` or `transform:
+translate3d(0, 0, 0)` (null transform hack), but `backface-visibility` is used
+here to avoid overriding the more popular `transform` property.
 
 These hacks are required for browsers that do not support `will-change`.
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,16 @@ var postcss = require('postcss');
 module.exports = postcss.plugin('postcss-will-change', function () {
     return function (css) {
         css.walkDecls('will-change', function (decl) {
+            // Find if a backface-visibility is already present
+            var isBackfaceVisibilityPresent = false;
+            decl.parent.walkDecls('backface-visibility', function () {
+                isBackfaceVisibilityPresent = true;
+            });
+
+            if (isBackfaceVisibilityPresent) {
+                return;
+            }
+
             decl.cloneBefore({ prop: 'backface-visibility', value: 'hidden' });
         });
     };

--- a/test/test.js
+++ b/test/test.js
@@ -14,4 +14,17 @@ describe('postcss-will-change', function () {
              'a{ backface-visibility: hidden; will-change: transform; }');
     });
 
+    it('does not override existing properties', function () {
+        test('a{ backface-visibility: visible; will-change: transform; }',
+             'a{ backface-visibility: visible; will-change: transform; }');
+    });
+
+    it('does not get confused by other selectors', function () {
+        var source = 'a{ backface-visibility: visible; } ' +
+          '.foo { will-change: transform; }';
+        var expected = 'a{ backface-visibility: visible; } ' +
+          '.foo { backface-visibility: hidden; will-change: transform; }';
+        test(source, expected);
+    });
+
 });


### PR DESCRIPTION
If a selector already has a backface-visibility property, this plugin
would add its own anyway, which could override the existing
backface-visibilty property. This commit aims at preventing this from
happening.

Since there is already a backface-visibility property in this case, we
don't actually need to add one of our own.